### PR TITLE
Split transcript and video into separate WebAnnotations.

### DIFF
--- a/raw_manifests/rfta_video.json
+++ b/raw_manifests/rfta_video.json
@@ -7,7 +7,7 @@
 			"Interview with John Schwartz and Sally Reamer, 2020-03-13"
 		]
 	},
-	"rights": "https://creativecommons.org/licenses/by/4.0",
+	"rights": "https://creativecommons.org/licenses/by/4.0/",
 	"metadata": [{
 			"label": {
 				"en": ["Topics"]

--- a/raw_manifests/rfta_video.json
+++ b/raw_manifests/rfta_video.json
@@ -47,19 +47,27 @@
 		"items": [{
 			"id": "https://raw.githubusercontent.com/markpbaggett/utk_iiif_recipes/main/raw_manifests/rfta_video/canvas/page",
 			"type": "AnnotationPage",
-			"items": [{
-				"id": "https://raw.githubusercontent.com/markpbaggett/utk_iiif_recipes/main/raw_manifests/rfta_video/canvas/page/annotation",
-				"type": "Annotation",
-				"motivation": "supplementing",
-				"body": [{
+			"items": [
+				{
+					"id": "https://raw.githubusercontent.com/markpbaggett/utk_iiif_recipes/main/raw_manifests/rfta_video/canvas/page/annotation",
+					"type": "Annotation",
+					"motivation": "painting",
+					"body": [{
 						"id": "https://trace.lib.utk.edu/assets/rfta/20200313_Schwartz_John-Reamer_Salley_edited.mp4",
 						"type": "Video",
 						"height": 360,
 						"width": 480,
 						"duration": 2190,
 						"format": "video/mp4"
-					},
-					{
+					}
+					],
+					"target": "https://raw.githubusercontent.com/markpbaggett/utk_iiif_recipes/main/raw_manifests/rfta_video/canvas"
+				},
+				{
+					"id": "https://raw.githubusercontent.com/markpbaggett/utk_iiif_recipes/main/raw_manifests/rfta_video/canvas/page/annotation2",
+					"type": "Annotation",
+					"motivation": "supplementing",
+					"body": [{
 						"id": "https://raw.githubusercontent.com/markpbaggett/utk_iiif_recipes/main/raw_transcripts/20200313_Schwartz_John-Reamer_Salley_Canvas_corrected.vtt",
 						"type": "Text",
 						"format": "text/vtt",
@@ -69,10 +77,11 @@
 							]
 						},
 						"language": "en"
-					}
-				],
-				"target": "https://raw.githubusercontent.com/markpbaggett/utk_iiif_recipes/main/raw_manifests/rfta_video/canvas"
-			}]
+					}],
+					"target": "https://raw.githubusercontent.com/markpbaggett/utk_iiif_recipes/main/raw_manifests/rfta_video/canvas"
+				}
+
+			]
 		}]
 	}],
 	"structures": [{


### PR DESCRIPTION
# What does this do

1. Splits transcripts and videos into separate [WebAnnotations](https://www.w3.org/TR/annotation-model/#annotations).
2. Switches the CC license so that it is valid.

# What am I changing

A few weeks ago, I noticed this [issue](https://github.com/IIIF/cookbook-recipes/issues/237) in the IIIF cookbook.  It explained that transcripts should have a motivation of `supplementing`. Originally, we had this as `painting` which [presentation v3 translates](https://hyp.is/k6oTcJPREeuKEJOJUo1a9w/iiif.io/api/presentation/3.0/) to the transcript MUST be present on its target canvas. We of course don't want this because we may have multiple transcripts in several different languages, or we may want to allow a user to simply turn off the captioning.

When I changed this originally, I wasn't thinking and forgot that the body of our `Annotation` referred to both the transcript and the video. Therefore, when I changed the motivation value to `supplementing`, it made the video be optionally displayed too.  This changes things to treat the video and transcript as two separate [WebAnnotations](https://www.w3.org/TR/annotation-model/#annotations) with different bodies and motivations.

I also switched the CC license which is wrong in the originating spreadsheet and thus invalidates the manifest.

# Reviewing and Testing

1. Does the manifest validate?
2. Does it still work in the test [Mirador version](https://deploy-preview-3379--mirador-dev.netlify.app/) with closed captioning support?
3. Are there questions regarding the manifest and [presentation v3](https://iiif.io/api/presentation/3.0/) or [WebAnnotations](https://www.w3.org/TR/annotation-model/#annotations)? If so, don't merge until we talk this out.

